### PR TITLE
Extend kubeorch to support multiple workload types

### DIFF
--- a/floworch/convert.go
+++ b/floworch/convert.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/myntra/shuttle-engine/types"
 )
 
@@ -24,12 +25,24 @@ func convertMetaTagsToReplacers(step *types.Step, flowOrchRequest types.FlowOrch
 			if strings.Contains(convertedValue, "\n") {
 				convertedValue = "|\n" + twelveSpaces + strings.Replace(convertedValue, "\n", "\n"+twelveSpaces, -1)
 			}
+
 		case map[string]interface{}:
 			convertedValueInBytes, err := json.Marshal(step.Meta[parser].Value)
 			if err != nil {
 				return err
 			}
 			convertedValue = string(convertedValueInBytes)
+		case []interface{}:
+			convertedValueInBytes, err := json.Marshal(step.Meta[parser].Value)
+			if err != nil {
+				return err
+			}
+			yml, _ := yaml.JSONToYAML(convertedValueInBytes)
+			convertedValue = string(string(yml))
+			spaces := "        "
+			if strings.Contains(convertedValue, "\n") {
+				convertedValue = "\n" + spaces + strings.Replace(convertedValue, "\n", "\n"+spaces, -1)
+			}
 		}
 		// step.Meta[parser].ConvertedValue = convertedValue
 		step.Replacers[step.Meta[parser].Name] = convertedValue

--- a/kuborch/healthcheck.go
+++ b/kuborch/healthcheck.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/myntra/shuttle-engine/helpers"
+)
+
+func HealthCheckHandler(w http.ResponseWriter, req *http.Request) {
+	eRes := helpers.Response{
+		State: "online",
+		Code:  200,
+	}
+	inBytes, _ := json.Marshal(eRes)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write(inBytes)
+}

--- a/kuborch/main.go
+++ b/kuborch/main.go
@@ -30,5 +30,6 @@ func main() {
 	log.Printf("Starting up the server at %d", port)
 	router := mux.NewRouter()
 	router.HandleFunc("/executeworkload", executeWorkload).Methods("Post")
+	router.HandleFunc("/health", HealthCheckHandler).Methods("Get")
 	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(port), router))
 }

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -108,6 +108,12 @@ func JobWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadRes
 	for {
 		select {
 		case event := <-ch:
+			if event.Object == nil {
+				log.Println("-- Received nil event from closed channel, refreshing channel --")
+				watcher, _ = clientset.BatchV1().Jobs(namespace).Watch(listOpts)
+				ch = watcher.ResultChan()
+				continue
+			}
 			job := event.Object.(*batchv1.Job)
 			log.Printf("Job: %s -> Active: %d, Succeeded: %d, Failed: %d, Spec Completions: %d",
 				job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed, *job.Spec.Completions)

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -179,8 +179,10 @@ func DeploymentWatch(clientset *kubernetes.Clientset, resultChan chan types.Work
 			} else if event.Type == watch.Modified {
 				dpl := event.Object.(*appsv1.Deployment)
 				log.Printf("*dpl.Spec.Replicas=%d, dpl.Status=%+v", *dpl.Spec.Replicas, dpl.Status)
-				if *dpl.Spec.Replicas == dpl.Status.Replicas &&
-					dpl.Status.Replicas == dpl.Status.ReadyReplicas {
+				if dpl.Status.UpdatedReplicas == *(dpl.Spec.Replicas) &&
+					dpl.Status.Replicas == *(dpl.Spec.Replicas) &&
+					dpl.Status.AvailableReplicas == *(dpl.Spec.Replicas) &&
+					dpl.Status.ObservedGeneration >= dpl.Generation {
 					resultChan <- types.WorkloadResult{
 						Result:  types.SUCCEEDED,
 						Details: "",

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -40,6 +40,8 @@ func StatefulSetWatch(clientset *kubernetes.Clientset, resultChan chan types.Wor
 				log.Printf("*sfs.Spec.Replicas=%d, sfs.Status=%+v", *sfs.Spec.Replicas, sfs.Status)
 				if *sfs.Spec.Replicas == sfs.Status.Replicas &&
 					sfs.Status.Replicas == sfs.Status.ReadyReplicas &&
+					sfs.Status.Replicas == sfs.Status.UpdatedReplicas &&
+					sfs.Status.CurrentReplicas == sfs.Status.UpdatedReplicas &&
 					sfs.Status.CurrentRevision == sfs.Status.UpdateRevision {
 					resultChan <- types.WorkloadResult{
 						Result:  types.SUCCEEDED,

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -200,7 +200,7 @@ func DeploymentWatch(clientset *kubernetes.Clientset, resultChan chan types.Work
 					return
 				}
 			}
-		case <-time.After(15 * time.Second):
+		case <-time.After(180 * time.Second):
 			resultChan <- types.WorkloadResult{
 				Result:  types.FAILED,
 				Details: "Timed out while waiting for events with Deployment",

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/myntra/shuttle-engine/types"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+// StatefulSetWatch ...
+func StatefulSetWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadResult, namespace string, listOpts metav1.ListOptions) {
+
+	watcher, err := clientset.AppsV1().StatefulSets(namespace).Watch(listOpts)
+	if err != nil {
+		fmt.Println("Failure in creating the watcher")
+		fmt.Println(err)
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case event := <-ch:
+			if event.Type == watch.Deleted {
+				resultChan <- types.WorkloadResult{
+					Result:  types.SUCCEEDED,
+					Details: "",
+					Kind:    "StatefulSet",
+				}
+				return
+			} else if event.Type == watch.Modified {
+				sfs := event.Object.(*appsv1.StatefulSet)
+				log.Printf("*sfs.Spec.Replicas=%d, sfs.Status=%+v", *sfs.Spec.Replicas, sfs.Status)
+				if *sfs.Spec.Replicas == sfs.Status.Replicas &&
+					sfs.Status.Replicas == sfs.Status.ReadyReplicas &&
+					sfs.Status.CurrentRevision == sfs.Status.UpdateRevision {
+					resultChan <- types.WorkloadResult{
+						Result:  types.SUCCEEDED,
+						Details: "",
+						Kind:    "StatefulSet",
+					}
+					return
+				}
+			}
+		case <-time.After(10 * time.Second):
+			resultChan <- types.WorkloadResult{
+				Result:  types.FAILED,
+				Details: "Timed out while waiting for events with StatefulSet",
+				Kind:    "StatefulSet",
+			}
+		}
+	}
+}
+
+// ServiceWatch ...
+func ServiceWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadResult, namespace string, listOpts metav1.ListOptions) {
+
+	watcher, err := clientset.CoreV1().Services(namespace).Watch(listOpts)
+	if err != nil {
+		fmt.Println("Failure in creating the watcher")
+		fmt.Println(err)
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case event := <-ch:
+			fmt.Println(event.Type)
+			if event.Type == watch.Deleted || event.Type == watch.Added {
+				resultChan <- types.WorkloadResult{
+					Result:  types.SUCCEEDED,
+					Details: "",
+					Kind:    "Service",
+				}
+				return
+			}
+		case <-time.After(5 * time.Second):
+			resultChan <- types.WorkloadResult{
+				Result:  types.FAILED,
+				Details: "Timed out while waiting for events with Service",
+				Kind:    "StatefulSet",
+			}
+		}
+	}
+}
+
+// JobWatch ...
+func JobWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadResult, namespace string, listOpts metav1.ListOptions) {
+	watcher, err := clientset.BatchV1().Jobs(namespace).Watch(listOpts)
+	if err != nil {
+		log.Println("Failure in creating the watcher")
+		log.Println(err)
+		return
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case event := <-ch:
+			job := event.Object.(*batchv1.Job)
+			log.Printf("Job: %s -> Active: %d, Succeeded: %d, Failed: %d, Spec Completions: %d",
+				job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed, *job.Spec.Completions)
+			switch event.Type {
+			case watch.Modified:
+				sendResponse := false
+				log.Println("New modification poll")
+				res := types.FAILED
+				errMsg := "Job Failed on K8s"
+
+				if job.Status.Failed > 0 {
+					log.Println("Workload Failed")
+					sendResponse = true
+				}
+
+				if job.Status.Active == 0 &&
+					job.Status.Failed == 0 &&
+					job.Status.Succeeded == *job.Spec.Completions {
+
+					log.Println("Workload Succeeded")
+					res = types.SUCCEEDED
+					errMsg = ""
+					sendResponse = true
+				}
+
+				if sendResponse {
+					log.Println("Stopping Poll")
+					resultChan <- types.WorkloadResult{
+						// UniqueKey: uniqueKey,
+						Result:  res,
+						Details: errMsg,
+						Kind:    "Job",
+					}
+					return
+				}
+			}
+		case <-time.After(30 * time.Minute):
+			log.Println("Timeout for Job !!")
+			log.Println("Stopping Poll")
+			resultChan <- types.WorkloadResult{
+				// UniqueKey: uniqueKey,
+				Result:  types.FAILED,
+				Details: "timeout",
+				Kind:    "Job",
+			}
+		}
+	}
+}

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -144,7 +144,7 @@ func JobWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadRes
 					return
 				}
 			}
-		case <-time.After(30 * time.Minute):
+		case <-time.After(45 * time.Minute):
 			log.Println("Timeout for Job !!")
 			log.Println("Stopping Poll")
 			resultChan <- types.WorkloadResult{
@@ -153,6 +153,7 @@ func JobWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadRes
 				Details: "timeout",
 				Kind:    "Job",
 			}
+			return
 		}
 	}
 }

--- a/kuborch/workload.go
+++ b/kuborch/workload.go
@@ -160,6 +160,8 @@ func runKubeCTL(uniqueKey, workloadPath string) {
 			go StatefulSetWatch(Clientset, watchChannel, "default", listOpts)
 		case "Service":
 			go ServiceWatch(Clientset, watchChannel, "default", listOpts)
+		case "Deployment":
+			go DeploymentWatch(Clientset, watchChannel, "default", listOpts)
 		default:
 			log.Println("Unknown workload. Completed")
 		}

--- a/kuborch/workload.go
+++ b/kuborch/workload.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -16,9 +18,11 @@ import (
 
 	r "gopkg.in/gorethink/gorethink.v4"
 
-	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func executeWorkload(w http.ResponseWriter, req *http.Request) {
@@ -43,7 +47,9 @@ func executeWorkload(w http.ResponseWriter, req *http.Request) {
 	workloadPath := "./yaml/" + step.UniqueKey + ".yaml"
 	fileContentInBytes := replaceVariables(yamlFromDB, step, workloadPath)
 	helpers.PanicOnErrorAPI(err, w)
+
 	err = ioutil.WriteFile(workloadPath, fileContentInBytes, 0777)
+
 	helpers.PanicOnErrorAPI(err, w)
 	go runKubeCTL(step.UniqueKey, workloadPath)
 	eRes := helpers.Response{
@@ -74,8 +80,10 @@ func runKubeCTL(uniqueKey, workloadPath string) {
 	resChan := make(chan types.WorkloadResult)
 	go func(uniqueKey string) {
 		for {
+			log.Println("Waiting on result channel for " + uniqueKey)
 			select {
 			case wr := <-resChan:
+				log.Println("Sending floworch result for " + uniqueKey)
 				_, err := helpers.Post("http://localhost:5500/callback", wr, nil)
 				if err != nil {
 					log.Println(err)
@@ -100,66 +108,94 @@ func runKubeCTL(uniqueKey, workloadPath string) {
 	log.Println("yaml executed")
 	// Poll Kube API for result of workload
 	log.Println("job-name=" + uniqueKey)
-	listOpts := metav1.ListOptions{
-		LabelSelector: "job-name=" + uniqueKey,
-	}
 	log.Println("listopts done")
 	time.Sleep(time.Duration(2 * time.Second))
-	watcherI, err := Clientset.BatchV1().Jobs("default").Watch(listOpts)
+
+	k8File, err := os.Open(workloadPath)
 	if err != nil {
-		resChan <- types.WorkloadResult{
-			UniqueKey: uniqueKey,
-			Result:    types.FAILED,
-			Details:   err.Error(),
-		}
-		return
+		log.Fatal(err)
 	}
-	log.Println("Created watcherI")
-	ch := watcherI.ResultChan()
-	defer watcherI.Stop()
+	reader := bufio.NewReader(k8File)
+	decoder := yaml.NewYAMLOrJSONDecoder(reader, 2048)
+	workloadTrackMap := make(map[string]int)
+
+	watchChannel := make(chan types.WorkloadResult)
+	defer close(watchChannel)
+	for {
+		ext := runtime.RawExtension{}
+		if err := decoder.Decode(&ext); err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Fatal(err)
+		}
+
+		log.Println("-----------------------------")
+		log.Println("raw: ", string(ext.Raw))
+
+		versions := &runtime.VersionedObjects{}
+		obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(ext.Raw, nil, versions)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// GroupKind type
+		workloadKind := gvk.GroupKind().Kind
+		// non existent value is default which is 0
+		workloadTrackMap[workloadKind]++
+
+		objectKindI := obj.GetObjectKind()
+		structuredObj := objectKindI.(*unstructured.Unstructured)
+		labelSet := structuredObj.GetLabels()
+
+		listOpts := metav1.ListOptions{
+			LabelSelector: labels.Set(labelSet).String(),
+		}
+
+		log.Println(workloadKind)
+		switch workloadKind {
+		case "Job":
+			go JobWatch(Clientset, watchChannel, "default", listOpts)
+		case "StatefulSet":
+			go StatefulSetWatch(Clientset, watchChannel, "default", listOpts)
+		case "Service":
+			go ServiceWatch(Clientset, watchChannel, "default", listOpts)
+		default:
+			log.Println("Unknown workload. Completed")
+		}
+	}
+
+	totalWorkload := len(workloadTrackMap)
+	receivedResults := 0
+
+	/**
+	 * result check receieved from go routines
+	 */
 	for {
 		select {
-		case event := <-ch:
-			job, isPresent := event.Object.(*batchv1.Job)
-			if !isPresent {
-				log.Println("Unknown Object Type")
-				resChan <- types.WorkloadResult{
-					UniqueKey: uniqueKey,
-					Result:    types.FAILED,
-					Details:   "Unknown Object Type",
-				}
+		case event := <-watchChannel:
+			log.Println("++++++++++++++++++++++++++Recieved Watch Event++++++++++++++++++++++++++++++")
+			log.Println(event)
+			receivedResults += 1
+			if event.Result == types.FAILED {
+				fmt.Println(event.Details)
 				return
 			}
-			log.Printf("Job: %s -> Active: %d, Succeeded: %d, Failed: %d",
-				job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed)
-			switch event.Type {
-			case watch.Modified:
-				sendResponse := false
-				log.Println("New modification poll")
-				res := types.FAILED
-				errMsg := "Job Failed on K8s"
-				if job.Status.Failed > 0 {
-					log.Println("Workload Failed")
-					sendResponse = true
-				}
-				if job.Status.Active == 0 {
-					if job.Status.Succeeded == 1 {
-						res = types.SUCCEEDED
-						errMsg = ""
-					}
-					log.Println("Workload Succeeded")
-					sendResponse = true
-				}
-				if sendResponse {
-					log.Println("Stopping Poll")
-					resChan <- types.WorkloadResult{
-						UniqueKey: uniqueKey,
-						Result:    res,
-						Details:   errMsg,
-					}
-					return
-				}
+			if workloadTrackMap[event.Kind] == 1 {
+				delete(workloadTrackMap, event.Kind)
+			} else {
+				workloadTrackMap[event.Kind] -= 1
 			}
+
+			if receivedResults == totalWorkload && len(workloadTrackMap) == 0 {
+				log.Println("Succesfully completed workload", uniqueKey)
+				// hack for unique key specific stuff of floworch
+				event.UniqueKey = uniqueKey
+				resChan <- event
+				return
+			}
+
 		}
 	}
+
 }

--- a/kuborch/workload.go
+++ b/kuborch/workload.go
@@ -147,21 +147,28 @@ func runKubeCTL(uniqueKey, workloadPath string) {
 		objectKindI := obj.GetObjectKind()
 		structuredObj := objectKindI.(*unstructured.Unstructured)
 		labelSet := structuredObj.GetLabels()
+		namespace := structuredObj.GetNamespace()
 
 		listOpts := metav1.ListOptions{
 			LabelSelector: labels.Set(labelSet).String(),
 		}
 
 		log.Println(workloadKind)
+
+		if namespace == "" {
+			namespace = "default"
+		}
+
+		log.Println(namespace)
 		switch workloadKind {
 		case "Job":
-			go JobWatch(Clientset, watchChannel, "default", listOpts)
+			go JobWatch(Clientset, watchChannel, namespace, listOpts)
 		case "StatefulSet":
-			go StatefulSetWatch(Clientset, watchChannel, "default", listOpts)
+			go StatefulSetWatch(Clientset, watchChannel, namespace, listOpts)
 		case "Service":
-			go ServiceWatch(Clientset, watchChannel, "default", listOpts)
+			go ServiceWatch(Clientset, watchChannel, namespace, listOpts)
 		case "Deployment":
-			go DeploymentWatch(Clientset, watchChannel, "default", listOpts)
+			go DeploymentWatch(Clientset, watchChannel, namespace, listOpts)
 		default:
 			log.Println("Unknown workload. Completed")
 		}

--- a/kuborch/workload.go
+++ b/kuborch/workload.go
@@ -188,6 +188,8 @@ func runKubeCTL(uniqueKey, workloadPath string) {
 			receivedResults += 1
 			if event.Result == types.FAILED {
 				fmt.Println(event.Details)
+				event.UniqueKey = uniqueKey
+				resChan <- event
 				return
 			}
 			if workloadTrackMap[event.Kind] == 1 {

--- a/types/orch.go
+++ b/types/orch.go
@@ -25,6 +25,7 @@ type WorkloadResult struct {
 	UniqueKey string `json:"uniqueKey"`
 	Result    string `json:"result"`
 	Details   string `json:"details"`
+	Kind      string `json:"kind"`
 }
 
 // FlowOrchRequest ...


### PR DESCRIPTION
Summary of changes
- Workload type now supports Job, Service and Statefulset kind
- Ability to process multiple workloads within single ```execute workload``` request
- Now depends on the presence of unique labels with workload objects.