### PR TITLE
channel cleanup immediately post parallel failure

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 // Config ...
 type Config struct {
+	RethinkHost    string  `yaml:"rethinkHost"`
 	Filter         Filters `yaml:"filters"`
 	TotalTimeTable string  `yaml:"totalTimeTable"`
 	StepTimeTable  string  `yaml:"stepTimeTable"`

--- a/floworch/callback.go
+++ b/floworch/callback.go
@@ -16,11 +16,9 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(workloadResult)
 	if stepChannelDetails, isPresent := MapOfDeleteChannelDetails[workloadResult.UniqueKey]; isPresent {
 		stepChannelDetails.DeleteChannel <- workloadResult
-		defer close(stepChannelDetails.DeleteChannel)
-		defer delete(MapOfDeleteChannelDetails, workloadResult.UniqueKey)
 		log.Println("Sent channel status")
 	} else {
-		log.Println("Channel not found on process. Should send to raft here")
+		log.Println("Channel not found on process. There must have been a failed step which deleted this running step")
 	}
 	cr := types.CallbackResponse{
 		State: "Callback ACK",

--- a/floworch/content.go
+++ b/floworch/content.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/myntra/shuttle-engine/config"
 	"github.com/myntra/shuttle-engine/types"
 	gorethink "gopkg.in/gorethink/gorethink.v4"
 )
@@ -8,7 +9,7 @@ import (
 func getContent(flowOrchRequest types.FlowOrchRequest) (types.YAMLFromDB, error) {
 	var yamlFromDB types.YAMLFromDB
 	rdbSession, err := gorethink.Connect(gorethink.ConnectOpts{
-		Address:  "dockinsrethink.myntra.com:28015",
+		Address:  config.GetConfig().RethinkHost,
 		Database: "shuttleservices",
 	})
 	if err != nil {
@@ -31,7 +32,7 @@ func getContent(flowOrchRequest types.FlowOrchRequest) (types.YAMLFromDB, error)
 
 func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 	rdbSession, err := gorethink.Connect(gorethink.ConnectOpts{
-		Address:  "dockinsrethink.myntra.com:28015",
+		Address:  config.GetConfig().RethinkHost,
 		Database: "shuttleservices",
 	})
 	if err != nil {

--- a/floworch/main.go
+++ b/floworch/main.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// MapOfDeleteChannelDetails ...
-	MapOfDeleteChannelDetails = make(map[string]types.DeleteChannelDetails)
+	MapOfDeleteChannelDetails = make(map[string]*types.DeleteChannelDetails)
 
 	// EnableMetrics will have the value of an environment variable("ENABLE_METRICS") which enables the metrics if its value is "ON"
 	EnableMetrics bool
@@ -25,6 +25,7 @@ func main() {
 	router := mux.NewRouter()
 
 	if err := config.ReadConfig(); err != nil {
+		log.Println(err)
 		return
 	}
 

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -132,7 +132,7 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 								logger.Println(MapOfDeleteChannelDetails)
 								// Hit kuborch API to create job
 								everySecond := time.Tick(5 * time.Second)
-								for {
+								for MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel != nil {
 									logger.Printf("thread - %s - Workload not complete", run.Steps[index].Name)
 									select {
 									case statusInChannel := <-MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel:
@@ -152,6 +152,8 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 											imageList[index] = run.Steps[index].UniqueKey + ":" + run.Steps[index].Name
 										}
 										saveKVPairs(run.Steps[index], run)
+										close(MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel)
+										delete(MapOfDeleteChannelDetails, run.Steps[index].UniqueKey)
 										return
 									// This might not be needed
 									case <-everySecond:

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -132,7 +132,7 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 								logger.Println(MapOfDeleteChannelDetails)
 								// Hit kuborch API to create job
 								everySecond := time.Tick(5 * time.Second)
-								for MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel != nil {
+								for {
 									logger.Printf("thread - %s - Workload not complete", run.Steps[index].Name)
 									select {
 									case statusInChannel := <-MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel:
@@ -152,8 +152,6 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 											imageList[index] = run.Steps[index].UniqueKey + ":" + run.Steps[index].Name
 										}
 										saveKVPairs(run.Steps[index], run)
-										close(MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel)
-										delete(MapOfDeleteChannelDetails, run.Steps[index].UniqueKey)
 										return
 									// This might not be needed
 									case <-everySecond:

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -45,13 +45,11 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 						if !singleDeleteChannelDetail.IgnoreErrors {
 							singleDeleteChannelDetail.DeleteChannel <- types.WorkloadResult{
 								UniqueKey: uniqueKey,
-								Result:    "Failed",
+								Result:    types.ABORTED,
 							}
-							close(singleDeleteChannelDetail.DeleteChannel)
-							delete(MapOfDeleteChannelDetails, uniqueKey)
 							// TODO : Stop jobs if they are running
 						} else {
-							logger.Printf("There are workloads which ignoreErrors. Running them")
+							logger.Printf("There are workloads which ignoreErrors. Continuing with them")
 							isEnd = false
 						}
 					}
@@ -126,13 +124,13 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 									DeleteChannel: make(chan types.WorkloadResult),
 									IgnoreErrors:  run.Steps[index].IgnoreErrors,
 								}
-								MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] = deleteChannelDetails
+								MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] = &deleteChannelDetails
 								logger.Printf("thread - %s - Started Delete Channel", run.Steps[index].Name)
 								logger.Println(run.Steps[index].UniqueKey)
 								logger.Println(MapOfDeleteChannelDetails)
 								// Hit kuborch API to create job
 								everySecond := time.Tick(5 * time.Second)
-								for {
+								for MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] != nil {
 									logger.Printf("thread - %s - Workload not complete", run.Steps[index].Name)
 									select {
 									case statusInChannel := <-MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel:
@@ -152,6 +150,8 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 											imageList[index] = run.Steps[index].UniqueKey + ":" + run.Steps[index].Name
 										}
 										saveKVPairs(run.Steps[index], run)
+										close(MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel)
+										delete(MapOfDeleteChannelDetails, run.Steps[index].UniqueKey)
 										return
 									// This might not be needed
 									case <-everySecond:

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -47,8 +47,8 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 								UniqueKey: uniqueKey,
 								Result:    "Failed",
 							}
-							defer close(singleDeleteChannelDetail.DeleteChannel)
-							defer delete(MapOfDeleteChannelDetails, uniqueKey)
+							close(singleDeleteChannelDetail.DeleteChannel)
+							delete(MapOfDeleteChannelDetails, uniqueKey)
 							// TODO : Stop jobs if they are running
 						} else {
 							logger.Printf("There are workloads which ignoreErrors. Running them")

--- a/helpers/error.go
+++ b/helpers/error.go
@@ -1,10 +1,9 @@
 package helpers
 
 import (
-	"log"
+	"fmt"
 	"net/http"
-
-	"github.com/go-errors/errors"
+	"runtime/debug"
 )
 
 // Response ...
@@ -25,13 +24,17 @@ func FailOnErr(err error, resChan *chan string) {
 
 // PrintErr ...
 func PrintErr(err error) {
-	log.Println(errors.Wrap(err, 3).ErrorStack())
+	fmt.Println(err.Error())
+	debug.PrintStack()
+	// log.Println(errors.Wrap(err, 3).ErrorStack())
 }
 
 // PanicOnErrorAPI ...
 func PanicOnErrorAPI(err error, w http.ResponseWriter) {
 	if err != nil {
-		log.Println(errors.Wrap(err, 3).ErrorStack())
+		fmt.Println(err.Error())
+		debug.PrintStack()
+		// log.Println(errors.Wrap(err, 3).ErrorStack())
 		SendResponse("Error : "+err.Error(), 500, w)
 	}
 }

--- a/kuborch/healthcheck.go
+++ b/kuborch/healthcheck.go
@@ -7,6 +7,7 @@ import (
 	"github.com/myntra/shuttle-engine/helpers"
 )
 
+// HealthCheckHandler ...
 func HealthCheckHandler(w http.ResponseWriter, req *http.Request) {
 	eRes := helpers.Response{
 		State: "online",

--- a/kuborch/main.go
+++ b/kuborch/main.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/myntra/shuttle-engine/config"
 	"github.com/myntra/shuttle-engine/helpers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -16,6 +18,7 @@ import (
 // Clientset ...
 var Clientset *kubernetes.Clientset
 
+// ClientConfigMap ...
 var ClientConfigMap map[string]ClientConfig
 
 // ConfigPath ...
@@ -41,6 +44,12 @@ type ClientConfig struct {
 }
 
 func main() {
+	if err := config.ReadConfig(); err != nil {
+		log.Println(err)
+		return
+	}
+	os.RemoveAll("./yaml")
+	_ = os.Mkdir("./yaml", 0777)
 	//Example for Running with configPath is ./kuborch -configPath=clustername:~/kube/config -configPath=clustername1:~/kube/config1
 	flag.Var(&myConfigList, "configPath", "Please provide the Config Map as -configPath=<name>:<configPath>")
 	flag.Parse()


### PR DESCRIPTION
**Current Working (Floworch)**

    All step start execution by creating a channel (called delete channel), to which they listen for the result (in their own goroutine) and update their own status as well flag for pipeline failure.
    There are no intermediate results, only the success/failure message is sent on the delete channel. Once a message is received in goroutine, it exits with no one else left to read from channel
    Channel closing (and deletion) happens only when event callback is received from kuborch
    When a step fails, a failure message will be sent for all running channels, but there deletion and closing is deferred, which means they will only get cleaned up once floworch orchestration loop is over (Major source of problem).

 

**Issues**

    Because of the deferred loop, floworch revisits the same running step in next loop and tries to send failure message, where the loop get stuck forever.
    Since goroutine of the running step gets cleaned up, there is also no one to read from channel which gets blocked when the running step finishes and returns the result, basically running step never gets cleaned up hence showing up in queue API results.


**Solution:**

Rather than deferring the channel close and delete, all running step channel should be closed and deleted immediately. So that floworch loop never finds it in next iteration.
