### PR TITLE
Solving the race condition without removing existing feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 // Config ...
 type Config struct {
+	RethinkHost    string  `yaml:"rethinkHost"`
 	Filter         Filters `yaml:"filters"`
 	TotalTimeTable string  `yaml:"totalTimeTable"`
 	StepTimeTable  string  `yaml:"stepTimeTable"`

--- a/floworch/callback.go
+++ b/floworch/callback.go
@@ -16,11 +16,9 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(workloadResult)
 	if stepChannelDetails, isPresent := MapOfDeleteChannelDetails[workloadResult.UniqueKey]; isPresent {
 		stepChannelDetails.DeleteChannel <- workloadResult
-		defer close(stepChannelDetails.DeleteChannel)
-		defer delete(MapOfDeleteChannelDetails, workloadResult.UniqueKey)
 		log.Println("Sent channel status")
 	} else {
-		log.Println("Channel not found on process. Should send to raft here")
+		log.Println("Channel not found on process. There must have been a failed step which deleted this running step")
 	}
 	cr := types.CallbackResponse{
 		State: "Callback ACK",

--- a/floworch/content.go
+++ b/floworch/content.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/myntra/shuttle-engine/config"
 	"github.com/myntra/shuttle-engine/types"
 	gorethink "gopkg.in/gorethink/gorethink.v4"
 )
@@ -8,7 +9,7 @@ import (
 func getContent(flowOrchRequest types.FlowOrchRequest) (types.YAMLFromDB, error) {
 	var yamlFromDB types.YAMLFromDB
 	rdbSession, err := gorethink.Connect(gorethink.ConnectOpts{
-		Address:  "dockinsrethink.myntra.com:28015",
+		Address:  config.GetConfig().RethinkHost,
 		Database: "shuttleservices",
 	})
 	if err != nil {
@@ -31,7 +32,7 @@ func getContent(flowOrchRequest types.FlowOrchRequest) (types.YAMLFromDB, error)
 
 func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 	rdbSession, err := gorethink.Connect(gorethink.ConnectOpts{
-		Address:  "dockinsrethink.myntra.com:28015",
+		Address:  config.GetConfig().RethinkHost,
 		Database: "shuttleservices",
 	})
 	if err != nil {

--- a/floworch/healthcheck.go
+++ b/floworch/healthcheck.go
@@ -27,7 +27,7 @@ func HealthCheckHandler(w http.ResponseWriter, req *http.Request) {
 func QueueStatusHandler(w http.ResponseWriter, req *http.Request) {
 	keys := make(map[string]string)
 	for k, v := range MapOfDeleteChannelDetails {
-		keys[k] = v.ID
+		keys[k] = time.Now().Sub(v.CreationTime).String()
 	}
 
 	response := make(map[string]interface{})

--- a/floworch/main.go
+++ b/floworch/main.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// MapOfDeleteChannelDetails ...
-	MapOfDeleteChannelDetails = make(map[string]types.DeleteChannelDetails)
+	MapOfDeleteChannelDetails = make(map[string]*types.DeleteChannelDetails)
 
 	// EnableMetrics will have the value of an environment variable("ENABLE_METRICS") which enables the metrics if its value is "ON"
 	EnableMetrics bool
@@ -25,6 +25,7 @@ func main() {
 	router := mux.NewRouter()
 
 	if err := config.ReadConfig(); err != nil {
+		log.Println(err)
 		return
 	}
 

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -45,13 +45,11 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 						if !singleDeleteChannelDetail.IgnoreErrors {
 							singleDeleteChannelDetail.DeleteChannel <- types.WorkloadResult{
 								UniqueKey: uniqueKey,
-								Result:    "Failed",
+								Result:    types.ABORTED,
 							}
-							defer close(singleDeleteChannelDetail.DeleteChannel)
-							defer delete(MapOfDeleteChannelDetails, uniqueKey)
-							// TODO : Stop jobs if they are running
+							// TODO : Hit kuborch API to abort executions
 						} else {
-							logger.Printf("There are workloads which ignoreErrors. Running them")
+							logger.Printf("There are workloads which ignoreErrors. Continuing with them")
 							isEnd = false
 						}
 					}
@@ -126,13 +124,13 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 									DeleteChannel: make(chan types.WorkloadResult),
 									IgnoreErrors:  run.Steps[index].IgnoreErrors,
 								}
-								MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] = deleteChannelDetails
+								MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] = &deleteChannelDetails
 								logger.Printf("thread - %s - Started Delete Channel", run.Steps[index].Name)
 								logger.Println(run.Steps[index].UniqueKey)
 								logger.Println(MapOfDeleteChannelDetails)
 								// Hit kuborch API to create job
 								everySecond := time.Tick(5 * time.Second)
-								for {
+								for MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] != nil {
 									logger.Printf("thread - %s - Workload not complete", run.Steps[index].Name)
 									select {
 									case statusInChannel := <-MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel:
@@ -152,13 +150,15 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 											imageList[index] = run.Steps[index].UniqueKey + ":" + run.Steps[index].Name
 										}
 										saveKVPairs(run.Steps[index], run)
-										return
+										close(MapOfDeleteChannelDetails[run.Steps[index].UniqueKey].DeleteChannel)
+										delete(MapOfDeleteChannelDetails, run.Steps[index].UniqueKey)
 									// This might not be needed
 									case <-everySecond:
 										logger.Printf("thread - %s - Nothing on the channels", run.Steps[index].Name)
 										logger.Printf("thread - %s - Context - %s", run.Steps[index].Name, run.Steps[index].UniqueKey)
 									}
 								}
+								log.Println("Exiting step callback select loop as channel is now nil", run.Steps[index].UniqueKey)
 							}(index)
 							run.Steps[index].Status = types.INPROGRESS
 							updateRunDetailsToDB(run)

--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -123,6 +123,7 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) bool {
 									Stage:         flowOrchRequest.Stage,
 									DeleteChannel: make(chan types.WorkloadResult),
 									IgnoreErrors:  run.Steps[index].IgnoreErrors,
+									CreationTime:  time.Now(),
 								}
 								MapOfDeleteChannelDetails[run.Steps[index].UniqueKey] = &deleteChannelDetails
 								logger.Printf("thread - %s - Started Delete Channel", run.Steps[index].Name)

--- a/glide.sh
+++ b/glide.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+mkdir -p $GOPATH/bin
+if [[ -f "/usr/bin/glide" || -f "/usr/local/bin/glide" ]]
+then
+	echo "glide found"
+else
+	echo "glide not found in /usr/bin/glide or /usr/local/bin/glide"
+        curl https://glide.sh/get | sh
+fi
+glide install
+if [ $? != 0 ];
+then
+	echo "Glide Install failed"
+    exit 1
+fi

--- a/helpers/error.go
+++ b/helpers/error.go
@@ -1,10 +1,9 @@
 package helpers
 
 import (
-	"log"
+	"fmt"
 	"net/http"
-
-	"github.com/go-errors/errors"
+	"runtime/debug"
 )
 
 // Response ...
@@ -25,13 +24,15 @@ func FailOnErr(err error, resChan *chan string) {
 
 // PrintErr ...
 func PrintErr(err error) {
-	log.Println(errors.Wrap(err, 3).ErrorStack())
+	fmt.Println(err.Error())
+	debug.PrintStack()
 }
 
 // PanicOnErrorAPI ...
 func PanicOnErrorAPI(err error, w http.ResponseWriter) {
 	if err != nil {
-		log.Println(errors.Wrap(err, 3).ErrorStack())
+		fmt.Println(err.Error())
+		debug.PrintStack()
 		SendResponse("Error : "+err.Error(), 500, w)
 	}
 }

--- a/kuborch/healthcheck.go
+++ b/kuborch/healthcheck.go
@@ -7,6 +7,7 @@ import (
 	"github.com/myntra/shuttle-engine/helpers"
 )
 
+// HealthCheckHandler ...
 func HealthCheckHandler(w http.ResponseWriter, req *http.Request) {
 	eRes := helpers.Response{
 		State: "online",

--- a/kuborch/main.go
+++ b/kuborch/main.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/myntra/shuttle-engine/config"
 	"github.com/myntra/shuttle-engine/helpers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -16,6 +18,7 @@ import (
 // Clientset ...
 var Clientset *kubernetes.Clientset
 
+// ClientConfigMap ...
 var ClientConfigMap map[string]ClientConfig
 
 // ConfigPath ...
@@ -41,6 +44,12 @@ type ClientConfig struct {
 }
 
 func main() {
+	if err := config.ReadConfig(); err != nil {
+		log.Println(err)
+		return
+	}
+	os.RemoveAll("./yaml")
+	_ = os.Mkdir("./yaml", 0777)
 	//Example for Running with configPath is ./kuborch -configPath=clustername:~/kube/config -configPath=clustername1:~/kube/config1
 	flag.Var(&myConfigList, "configPath", "Please provide the Config Map as -configPath=<name>:<configPath>")
 	flag.Parse()

--- a/kuborch/main.go
+++ b/kuborch/main.go
@@ -15,14 +15,16 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Clientset ...
-var Clientset *kubernetes.Clientset
+var (
+	// Clientset ...
+	Clientset *kubernetes.Clientset
 
-// ClientConfigMap ...
-var ClientConfigMap map[string]ClientConfig
+	// ClientConfigMap ...
+	ClientConfigMap map[string]ClientConfig
 
-// ConfigPath ...
-var ConfigPath *string
+	// ConfigPath ...
+	ConfigPath *string
+)
 
 type configsList []string
 

--- a/kuborch/watcher.go
+++ b/kuborch/watcher.go
@@ -115,12 +115,13 @@ func JobWatch(clientset *kubernetes.Clientset, resultChan chan types.WorkloadRes
 				continue
 			}
 			job := event.Object.(*batchv1.Job)
-			log.Printf("Job: %s -> Active: %d, Succeeded: %d, Failed: %d, Spec Completions: %d",
-				job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed, *job.Spec.Completions)
+			log.Printf("Job: %s -> Event: %s, Active: %d, Succeeded: %d, Failed: %d, Spec Completions: %d",
+				job.Name, event.Type, job.Status.Active, job.Status.Succeeded, job.Status.Failed, *job.Spec.Completions)
 			switch event.Type {
+			case watch.Added:
+				fallthrough
 			case watch.Modified:
 				sendResponse := false
-				log.Println("New modification poll")
 				res := types.FAILED
 				errMsg := "Job Failed on K8s"
 

--- a/types/orch.go
+++ b/types/orch.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 // WorkloadDetails ...
 type WorkloadDetails struct {
 	Stage            string `json:"stage"`
@@ -43,6 +45,7 @@ type DeleteChannelDetails struct {
 	Stage         string              `json:"stage"`
 	DeleteChannel chan WorkloadResult `json:"deleteChannel"`
 	IgnoreErrors  bool                `json:"ignoreErrors"`
+	CreationTime  time.Time           `json:"creationTime"`
 }
 
 const (


### PR DESCRIPTION
1. RethinkDB Host as a config and using it in both floworch and kuborch
2. Moving of close and delete from the caller to callee
3. Map of delete channels gives pointers so that they can be made nil
4. Printstack for errors
5. Creation of kuborch's yaml folder on startup
6. Logging the event type
7. Defaulting Job workload's label filter to the default job-name which is present for all job with job name as the value