### PR TITLE
create and update time for floworch run

### DIFF
--- a/floworch/content.go
+++ b/floworch/content.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/myntra/shuttle-engine/config"
 	"github.com/myntra/shuttle-engine/types"
 	gorethink "gopkg.in/gorethink/gorethink.v4"
@@ -39,6 +41,13 @@ func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 		return run, err
 	}
 	defer rdbSession.Close()
+
+	if run.CreatedTime.IsZero() {
+		run.CreatedTime = time.Now()
+	}
+
+	run.UpdatedTime = time.Now()
+
 	_, err = gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
 		Conflict: "update",
 	}).RunWrite(rdbSession)

--- a/types/db.go
+++ b/types/db.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 // YAMLFromRethink ...
 type YAMLFromRethink struct {
 	Name   string `json:"name"`
@@ -19,6 +21,8 @@ type Run struct {
 	Steps                 []Step                  `json:"steps" gorethink:"steps"`
 	KVPairsSavedOnSuccess []KVPairsSavedOnSuccess `json:"kvPairsSavedOnSuccess" gorethink:"kvPairsSavedOnSuccess"`
 	Status                string                  `json:"status" gorethink:"status"`
+	CreatedTime           time.Time               `json:"createdTime" gorethink:"createdTime"`
+	UpdatedTime           time.Time               `json:"updatedTime" gorethink:"updatedTime"`
 }
 
 // Step ...


### PR DESCRIPTION
Addition of:

- CreatedTime
- UpdatedTime

This leaves the current `createdon` attribute set from bcube untouched to keep the backward compatibility.

This will be used to showing live time on CI run (and time taken when run is finished)