### PR TITLE
fail ci pipeline for pipeline timeout

### DIFF
--- a/floworch/orch.go
+++ b/floworch/orch.go
@@ -190,6 +190,7 @@ func orchestrate(flowOrchRequest types.FlowOrchRequest, run *types.Run) string {
 			}
 		case <-timeout:
 			isEnd = true
+			hasWorkloadFailed = true
 			logger.Println("Timed out")
 		}
 	}


### PR DESCRIPTION
as of now hung step will keep running, while pipeline finishes
due to timeout but marking the whole pipeline as success.