### PR TITLE
Handling db inserts for deployment run table for new key

### DIFF
--- a/floworch/content.go
+++ b/floworch/content.go
@@ -28,19 +28,31 @@ func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 	if run.CreatedTime.IsZero() {
 		run.CreatedTime = time.Now()
 	}
-
 	run.UpdatedTime = time.Now()
 
-	_, err = gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
-		Conflict: "update",
-	}).RunWrite(config.RethinkSession)
-	if err != nil {
-		return run, err
+	if !DoesRunExists(run) {
+		_, err = gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
+			Conflict: "update",
+		}).RunWrite(config.RethinkSession)
+	} else {
+		_, err := gorethink.Table(run.Stage + "_runs").Filter(map[string]interface{}{
+			"id": run.ID,
+		}).Update(run).RunWrite(config.RethinkSession)
 	}
 	if err != nil {
 		return run, err
 	}
 	return run, nil
+}
+
+func DoesRunExists(run *types.Run) bool {
+	var dbrun *types.Run
+	cursor, _ := gorethink.Table(run.Stage + "_runs").
+		Filter(map[string]interface{}{
+			"id": run.Id,
+		}).Run(RethinkSession)
+	err := cursor.One(&dbrun)
+	return err == nil
 }
 
 // GetAbortDetails ...

--- a/floworch/content.go
+++ b/floworch/content.go
@@ -31,16 +31,16 @@ func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 	run.UpdatedTime = time.Now()
 
 	if !DoesRunExists(run) {
-		_, err = gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
+		_, err := gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
 			Conflict: "update",
 		}).RunWrite(config.RethinkSession)
 	} else {
 		_, err := gorethink.Table(run.Stage + "_runs").Filter(map[string]interface{}{
 			"id": run.ID,
 		}).Update(run).RunWrite(config.RethinkSession)
-	}
-	if err != nil {
-		return run, err
+		if err != nil {
+			return run, err
+		}
 	}
 	return run, nil
 }

--- a/floworch/content.go
+++ b/floworch/content.go
@@ -34,6 +34,9 @@ func updateRunDetailsToDB(run *types.Run) (*types.Run, error) {
 		_, err := gorethink.Table(run.Stage+"_runs").Insert(run, gorethink.InsertOpts{
 			Conflict: "update",
 		}).RunWrite(config.RethinkSession)
+		if err != nil {
+			return run, err
+		}
 	} else {
 		_, err := gorethink.Table(run.Stage + "_runs").Filter(map[string]interface{}{
 			"id": run.ID,

--- a/floworch/content.go
+++ b/floworch/content.go
@@ -49,8 +49,8 @@ func DoesRunExists(run *types.Run) bool {
 	var dbrun *types.Run
 	cursor, _ := gorethink.Table(run.Stage + "_runs").
 		Filter(map[string]interface{}{
-			"id": run.Id,
-		}).Run(RethinkSession)
+			"id": run.ID,
+		}).Run(config.RethinkSession)
 	err := cursor.One(&dbrun)
 	return err == nil
 }


### PR DESCRIPTION
Rehtinkdb has a length limitation on the primary key of 127 chars. We have to change the key to autogenerated rethink key.
This needs handling insert queries so we don't create duplicates.